### PR TITLE
Update pipeline to include smoke & e2e test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,6 +31,15 @@ steps:
     env:
       BUILDKITE_SPLITTER_TEST_FILE_PATTERN: "spec/acceptance/**/*_spec.rb"
 
+  - label: "Everything Else"
+    command: .buildkite/steps/run
+    key: everything_else
+    agents:
+      queue: "hosted-queue"
+    parallelism: 2
+    env:
+      BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN: "spec/{acceptance,unit}/**/*_spec.rb"
+
   - label: "Update Test Ownership?"
     branches: "main"
     plugins:

--- a/.buildkite/steps/run
+++ b/.buildkite/steps/run
@@ -30,4 +30,5 @@ docker run \
   --env BUILDKITE_PARALLEL_JOB \
   --env BUILDKITE_PARALLEL_JOB_COUNT \
   --env BUILDKITE_SPLITTER_TEST_FILE_PATTERN \
+  --env BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN \
   -it --rm app sh -c "test-splitter"


### PR DESCRIPTION
I noticed that I wasn't running all the tests in the suite... only the unit & acceptance tests.

I've updated the pipeline to run an everything else step which will run everything that's not a unit or acceptance test. 

Hopefully testing the exclude pattern. 