### PR TITLE
Move to the package install of the splitter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,8 @@ RUN apk add --no-cache \
     git \
     curl
 
-ENV BUILDKITE_TEST_SPLITTER_VERSION=v0.7.0 \
-  BUIlDKITE_TEST_SPLITTER_SHA1SUM=46fd237c316e418e45a769e6946c0ea027c51798
-
-RUN curl -fsSLO "https://github.com/buildkite/test-splitter/releases/download/${BUILDKITE_TEST_SPLITTER_VERSION}/test-splitter-linux-amd64" \
-  && echo "${BUIlDKITE_TEST_SPLITTER_SHA1SUM} test-splitter-linux-amd64" | sha1sum -c - \
-  && chmod +x test-splitter-linux-amd64 \
-  && mv test-splitter-linux-amd64 /usr/local/bin/test-splitter
+# test-splitter
+COPY --from=buildkite/test-splitter:v0.8.1 /usr/local/bin/test-splitter /usr/local/bin/test-splitter
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
- Updating the example test suite to use the latest version of the test splitter
- Uses the Buildkite Packages/Docker hosted version of the splitter instead of fetching from GitHub